### PR TITLE
ci: pass SCW_DEFAULT_ORGANIZATION_ID to deploy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_PROJECT_ID }}
+          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
           SCW_DEFAULT_REGION: fr-par
         run: |
           semver="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
scw CLI requires both project ID and organization ID; without the latter it fails with "organization ID is required" when listing namespaces.


Claude-Session: https://claude.ai/code/session_01Vqj8jF7aFHUev6CEvMFTvE