### PR TITLE
ci: open changelog as PR to satisfy branch protection rules

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate-changelog:
@@ -37,13 +38,23 @@ jobs:
           OUTPUT: NOTES.md
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Commit CHANGELOG.md
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore(changelog): update for ${{ github.ref_name }}"
-          git push origin HEAD:${{ github.event.repository.default_branch }}
+      # Branch protection on the default branch requires PRs and verified signatures,
+      # so we open a PR with a signed commit authored via the GitHub API instead of
+      # pushing directly. Requires "Allow GitHub Actions to create and approve pull
+      # requests" under Settings → Actions → General.
+      - name: Open changelog pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
+          add-paths: CHANGELOG.md
+          branch: chore/changelog-${{ github.ref_name }}
+          base: ${{ github.event.repository.default_branch }}
+          delete-branch: true
+          commit-message: "chore(changelog): update for ${{ github.ref_name }}"
+          title: "chore(changelog): update for ${{ github.ref_name }}"
+          body: |
+            Auto-generated changelog update for release `${{ github.ref_name }}`.
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2


### PR DESCRIPTION
The previous workflow pushed CHANGELOG.md directly to the default branch, which is now rejected because main requires changes via pull request and verified signatures. Switch to peter-evans/create-pull-request with sign-commits: true, which authors the commit through the GitHub API so it arrives signed and proposes the update as a PR.